### PR TITLE
Remove glibc 2.14 requirement from the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Requirements
 ============
 
 You need Python 2.7 (recommended), Python 3.3, Python 3.2, or PyPy. You
-need Linux 3.3 or newer, with glibc 2.14 or newer.
+need Linux 3.3 or newer.
 
 This should get you started on Debian/Ubuntu:
 


### PR DESCRIPTION
Glibc 2.14 shouldn't be listed as a requirement in the README anymore, because the syncfs backport should work with glibc <2.14.
