### PR TITLE
Use select_entity_from for SQLAlchemy 0.9+ compatibility

### DIFF
--- a/bedup/tracking.py
+++ b/bedup/tracking.py
@@ -329,7 +329,8 @@ class WindowedQuery(object):
             window_start = li[0].size
             window_end = li[-1].size
             # If we wanted to be subtle we'd use limits here as well
-            inodes = self.sess.query(Inode).select_from(self.filtered_s).join(
+            inodes = self.sess.query(Inode).select_entity_from(
+                self.filtered_s).join(
                 window_select, window_select.c.size == Inode.size
             ).order_by(-Inode.size, Inode.ino)
             inodes_by_size = groupby(inodes, lambda inode: inode.size)

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     # files dumped in random places
     'pycparser >= 2.9.1',
     'pyxdg',
-    'SQLAlchemy',
+    'SQLAlchemy >= 0.8.2', # needs Query.select_entity_from()
     'contextlib2',
 ]
 


### PR DESCRIPTION
SQLAlchemy 0.9 changed the behavior of Query.select_from(), and this
causes bedup memory usage to explode.  Starting in SQLAlchemy 0.8.2
there is a Query.select_entity_from() which preserves the old behavior,
and this tests fine with bedup on both old and new SQLAlchemy.

Fixes #42.
