### PR TITLE
Fix RuntimeError/Issue #67

### DIFF
--- a/bedup/platform/btrfs.py
+++ b/bedup/platform/btrfs.py
@@ -542,7 +542,7 @@ def read_root_tree(volume_fd):
     # Deal with parent_root_id > root_id,
     # happens after moving subvolumes.
     while ri_rel:
-        for (root_id, ri) in ri_rel.items():
+        for (root_id, ri) in dict(ri_rel).items():
             if ri.parent_root_id not in root_info:
                 continue
             parent_path = root_info[ri.parent_root_id].path


### PR DESCRIPTION
It seems this is caused by line 551 and the fact that in Python3 .items() creates an iterator object unlike Py2 which creates a copy of the object.  Using dict(ri_rel).items() creates an iterator of a copy of ri_rel allowing 551 to modify the original ri_rel without triggering an exception.

Tested on my own system without issues.
