### PR TITLE
Fix loop that modifies the dict it iterates over

### DIFF
--- a/bedup/platform/btrfs.py
+++ b/bedup/platform/btrfs.py
@@ -542,7 +542,7 @@ def read_root_tree(volume_fd):
     # Deal with parent_root_id > root_id,
     # happens after moving subvolumes.
     while ri_rel:
-        for (root_id, ri) in ri_rel.items():
+        for (root_id, ri) in list(ri_rel.items()):
             if ri.parent_root_id not in root_info:
                 continue
             parent_path = root_info[ri.parent_root_id].path


### PR DESCRIPTION
In python3, dict.items() returns a view that iterates over the
dictionary.  By creating a list from those items, the subsequent
modifications of the dictionary do not raise an exception.

This fixes the issue in https://github.com/g2p/bedup/issues/78 for me.