### PR TITLE
Fix sqlite3 exception on python >= 3.6 .

### DIFF
--- a/bedup/__main__.py
+++ b/bedup/__main__.py
@@ -85,11 +85,15 @@ def sql_setup(dbapi_con, con_record):
 
     # So that writers do not block readers
     # https://www.sqlite.org/wal.html
+    # WAL mode can not be set inside a trasaction, so disable transactions
+    old_isolation = dbapi_con.isolation_level
+    dbapi_con.isolation_level = None
     cur.execute('PRAGMA journal_mode = WAL')
     cur.execute('PRAGMA journal_mode')
     val = cur.fetchone()
     # SQLite 3.7 is required
     assert val == ('wal',), val
+    dbapi_con.isolation_level = old_isolation
 
 
 def get_session(args):


### PR DESCRIPTION
Bedup crashes on startup with:
 cannot change into wal mode from within a transaction

This commit fixes the error by temporarily disabling transactions.
For similar error reports and more discussion see:
https://github.com/yadayada/acd_cli/issues/509

Tested on python 3.6 only.